### PR TITLE
Don't add parameters without values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 The complete changelog, follows the format defined at https://keepachangelog.com/en/1.0.0/
 
+## [v1.00.3] - 2019-07-30
+### Fixed
+- Parameter's without values are being added to pagination URIs.
+
 ## [v1.00.2] - 2019-07-20
 ### Added
 - Add CHANGELOG.
@@ -11,7 +15,7 @@ The complete changelog, follows the format defined at https://keepachangelog.com
 
 ## [v1.00.1] - 2019-07-13
 ### Fixed
-- Exmaple incorrect.
+- Example incorrect.
 - Var missing dollar `$` in view.
 
 ## [v1.00.0] - 2019-07-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The complete changelog, follows the format defined at https://keepachangelog.com
 ## [v1.00.3] - 2019-07-30
 ### Fixed
 - Parameter's without values are being added to pagination URIs.
+- Spelling error in CHANGELOG.
 
 ## [v1.00.2] - 2019-07-20
 ### Added

--- a/src/resources/views/pagination.blade.php
+++ b/src/resources/views/pagination.blade.php
@@ -1,7 +1,9 @@
 @php $parameters = ''; @endphp
 
 @foreach ($uri['parameters'] as $field => $value)
-    @php $parameters .= '&' . $field . '=' . $value; @endphp
+    @if (strlen(trim($value)) > 0)
+        @php $parameters .= '&' . $field . '=' . $value; @endphp
+    @endif
 @endforeach
 
 <div class="table-pagination p-3">


### PR DESCRIPTION
- Parameter's without values are being added to pagination URIs.
- Spelling error in CHANGELOG.